### PR TITLE
Update reference.md

### DIFF
--- a/apps/dynamic/views/docs/reference.md
+++ b/apps/dynamic/views/docs/reference.md
@@ -83,7 +83,7 @@ or [Scenario Outlines](#scenario-outline), and an optional [Background](#backgro
 Some parts of Gherkin documents do not have to start with a keyword.
 
 On the lines following a `Feature`, `Scenario`, `Scenario Outline` or `Examples`
-you can write anything you like, as long as no line starts witha key a keyword.
+you can write anything you like, as long as no line starts with a keyword.
 
 ### Scenario
 


### PR DESCRIPTION
While reading the documentation from cucumber.io/docs/reference found a mistake below the Descriptions section. e.g. "long as no line starts witha key a keyword.". I have fixed it.
Please update in the main branch. thanks.
